### PR TITLE
fix: ensure parent dir exists

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,6 +9,7 @@ module.exports = {
   rules: {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/ban-types': 'off',
-    'no-empty-pattern': 'off'
+    'no-empty-pattern': 'off',
+    '@typescript-eslint/no-explicit-any': 'off'
   }
 }

--- a/src/main/features/installation.ts
+++ b/src/main/features/installation.ts
@@ -12,7 +12,8 @@ import fs from 'fs'
 import fsp from 'fs/promises'
 import workerpool from 'workerpool'
 import { getInstalledFilePath, getSymlinkFilePath } from '../utils'
-import { join } from 'path'
+import { join, resolve } from 'path'
+import { ensureDir } from 'fs-extra'
 
 export type installWorkerMessage = {
   status: string
@@ -74,7 +75,13 @@ const enableMod = async (
     installMapArr.map(async (x) => {
       const installedFilePath = getInstalledFilePath(modId, writeDirPath, x)
       const symlinkFilePath = getSymlinkFilePath(saveDirPath, x)
+      const symlinkParentDir = resolve(symlinkFilePath, '..')
+
       const fileStats = await fsp.stat(installedFilePath)
+      console.debug('Ensuring Destination directory exists %s', symlinkParentDir)
+      await ensureDir(symlinkParentDir)
+
+      console.log('Creating symlink %s -> %s', installedFilePath, symlinkFilePath)
       return fsp.symlink(
         installedFilePath,
         symlinkFilePath,

--- a/src/renderer/src/context/install.context.tsx
+++ b/src/renderer/src/context/install.context.tsx
@@ -10,6 +10,7 @@ import {
 } from 'src/client'
 import useSwr from 'swr'
 import { useSettings } from './settings.context'
+import { showErrorNotification, showSuccessNotification } from '../utils/notifications'
 
 export interface InstallContextValue {
   installStates?: Record<string, string>
@@ -45,37 +46,49 @@ export const InstallProvider: FC<{ children: ReactNode }> = ({ children }) => {
       })
     }
 
-    client.installation.installMod.query({
-      modId: entry.id,
-      installMapArr: installMapArrInferred,
-      writeDirPath: settings.writeDir,
-      version: latestRelease.version
-    })
+    client.installation.installMod
+      .query({
+        modId: entry.id,
+        installMapArr: installMapArrInferred,
+        writeDirPath: settings.writeDir,
+        version: latestRelease.version
+      })
+      .then(() => showSuccessNotification('Mod installing'))
+      .catch(showErrorNotification)
   }
   const uninstallMod = async (modId: string, installMapArr: EntryInstallMap[]) =>
-    await client.installation.uninstallMod.query({
-      modId,
-      installMapArr,
-      writeDirPath: settings.writeDir,
-      saveDirPath: settings.saveGameDir,
-      registryBaseUrl: settings.registryUrl
-    })
+    await client.installation.uninstallMod
+      .query({
+        modId,
+        installMapArr,
+        writeDirPath: settings.writeDir,
+        saveDirPath: settings.saveGameDir,
+        registryBaseUrl: settings.registryUrl
+      })
+      .then(() => showSuccessNotification('Mod uninstalled'))
+      .catch(showErrorNotification)
   const enableMod = async (modId: string, installMapArr: EntryInstallMap[]) =>
-    await client.installation.enableMod.query({
-      modId,
-      installMapArr,
-      writeDirPath: settings.writeDir,
-      saveDirPath: settings.saveGameDir,
-      registryBaseUrl: settings.registryUrl
-    })
+    await client.installation.enableMod
+      .query({
+        modId,
+        installMapArr,
+        writeDirPath: settings.writeDir,
+        saveDirPath: settings.saveGameDir,
+        registryBaseUrl: settings.registryUrl
+      })
+      .then(() => showSuccessNotification('Mod enabled'))
+      .catch(showErrorNotification)
   const disableMod = async (modId: string, installMapArr: EntryInstallMap[]) =>
-    await client.installation.disableMod.query({
-      modId,
-      installMapArr,
-      writeDirPath: settings.writeDir,
-      saveDirPath: settings.saveGameDir,
-      registryBaseUrl: settings.registryUrl
-    })
+    await client.installation.disableMod
+      .query({
+        modId,
+        installMapArr,
+        writeDirPath: settings.writeDir,
+        saveDirPath: settings.saveGameDir,
+        registryBaseUrl: settings.registryUrl
+      })
+      .then(() => showSuccessNotification('Mod disabled'))
+      .catch(showErrorNotification)
   const getInstallState = async (modId: string, installMapArr: EntryInstallMap[]) =>
     await client.installation.getInstallState.query({
       modId,


### PR DESCRIPTION
When enabling mod it fails if the parent dir is not present so I added an ensureDir before the enable.

Also added some feedback on the operations using toasts