### PR TITLE
Develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@nestjs/common": "^10.3.10",
         "@nestjs/core": "^10.3.10",
         "@nestjs/schedule": "^4.1.0",
+        "@nestjs/testing": "^10.4.15",
         "@nestjs/typeorm": "^10.0.2",
         "@trpc/client": "^10.45.2",
         "@trpc/server": "^10.45.2",
@@ -2234,6 +2235,39 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0"
       }
+    },
+    "node_modules/@nestjs/testing": {
+      "version": "10.4.15",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.4.15.tgz",
+      "integrity": "sha512-eGlWESkACMKti+iZk1hs6FUY/UqObmMaa8HAN9JLnaYkoLf1Jeh+EuHlGnfqo/Rq77oznNLIyaA3PFjrFDlNUg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/core": "^10.0.0",
+        "@nestjs/microservices": "^10.0.0",
+        "@nestjs/platform-express": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/microservices": {
+          "optional": true
+        },
+        "@nestjs/platform-express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/testing/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@nestjs/typeorm": {
       "version": "10.0.2",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@nestjs/core": "^10.3.10",
     "@nestjs/schedule": "^4.1.0",
     "@nestjs/typeorm": "^10.0.2",
+    "@nestjs/testing": "^10.4.15",
     "@trpc/client": "^10.45.2",
     "@trpc/server": "^10.45.2",
     "@types/bytes": "^3.1.4",

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -45,6 +45,8 @@ export interface EntryLatestRelease {
   tag: string
   /** The version of the release */
   version: string
+  /** The path to the exe if one exists */
+  exePath?: string
 }
 
 /**

--- a/src/main/app.module.ts
+++ b/src/main/app.module.ts
@@ -12,6 +12,7 @@ import { ConfigService } from './services/config.service'
 import { FsService } from './services/fs.service'
 import { RegistryService } from './services/registry.service'
 import { WriteDirectoryService } from './services/write-directory.service'
+import { VariablesService } from './services/variables.service'
 
 @Module({
   imports: [
@@ -28,7 +29,8 @@ import { WriteDirectoryService } from './services/write-directory.service'
     SubscriptionManager,
     TaskManager,
     LifecycleManager,
-    WriteDirectoryService
+    WriteDirectoryService,
+    VariablesService
   ]
 })
 export class AppModule {}

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -42,7 +42,7 @@ export const config: MainConfig = {
   },
   appOptions: {
     // Uncomment this line to enable verbose logging
-    // logger: ['log', 'error', 'warn', 'debug', 'verbose']
-    logger: ['log', 'error', 'warn']
+    logger: ['fatal', 'error', 'warn', 'log', 'debug', 'verbose']
+    // logger: ['error', 'warn', 'log']
   }
 }

--- a/src/main/entities/subscription.entity.ts
+++ b/src/main/entities/subscription.entity.ts
@@ -13,6 +13,9 @@ export class SubscriptionEntity {
   @Column()
   modName: string
 
+  @Column({ type: 'varchar', nullable: true })
+  exePath: string | null
+
   @Column({
     default: () => Date.now()
   })

--- a/src/main/manager/lifecycle-manager.service.ts
+++ b/src/main/manager/lifecycle-manager.service.ts
@@ -10,7 +10,7 @@ import { SubscriptionEntity } from '../entities/subscription.entity'
 import { FsService } from '../services/fs.service'
 import { WriteDirectoryService } from '../services/write-directory.service'
 import { HashPath } from '../utils/hash-path'
-import { SettingsManager } from './settings.manager'
+import { SettingsManager } from './settings.manager' 
 
 /**
  * Manages the toggling of a mod between enabled and disabled states

--- a/src/main/manager/lifecycle-manager.service.ts
+++ b/src/main/manager/lifecycle-manager.service.ts
@@ -10,7 +10,9 @@ import { SubscriptionEntity } from '../entities/subscription.entity'
 import { FsService } from '../services/fs.service'
 import { WriteDirectoryService } from '../services/write-directory.service'
 import { HashPath } from '../utils/hash-path'
-import { SettingsManager } from './settings.manager' 
+import { VariablesService } from '../services/variables.service'
+import { getUrlPartsForDownload } from '../functions/getUrlPartsForDownload'
+import { execFile } from 'node:child_process'
 
 /**
  * Manages the toggling of a mod between enabled and disabled states
@@ -34,12 +36,10 @@ export class LifecycleManager {
   private readonly writeDirectoryService: WriteDirectoryService
 
   @Inject()
-  private readonly settingsManager: SettingsManager
-
-  @Inject()
   private readonly fsService: FsService
 
-  /**
+  @Inject(VariablesService)
+  private variablesService: VariablesService /**
    * Toggles the mod between enabled and disabled states
    * If the mod is enabled, it will be disabled
    * If the mod is disabled, it will be enabled
@@ -67,9 +67,11 @@ export class LifecycleManager {
     for (const releaseAsset of releaseAssets) {
       this.logger.debug(`Enabling release asset: ${releaseAsset.id}`)
 
+      const { baseUrl } = getUrlPartsForDownload(releaseAsset.source)
+
       let srcPath = join(
         await this.writeDirectoryService.getWriteDirectoryForRelease(subscription.id, release.id),
-        releaseAsset.source
+        releaseAsset.source.replace(baseUrl, '')
       )
 
       // If the source is a hash path, we need to extract the base path and make sure the symlink is for the exploded folder including internal route
@@ -79,7 +81,7 @@ export class LifecycleManager {
         srcPath = join(hashPath.basePathWithoutExt, hashPath.hashPath)
       }
 
-      const targetPath = join(await this.settingsManager.getGameDir(), releaseAsset.target)
+      const targetPath = await this.variablesService.replaceVariables(releaseAsset.target)
       this.logger.debug(
         `Creating Symlink for release asset: ${releaseAsset.id} from ${srcPath} to ${targetPath}`
       )
@@ -116,6 +118,30 @@ export class LifecycleManager {
     }
     release.enabled = false
     await this.releaseRepository.save(release)
+  }
+
+  async runExe(modId: string, exePath: string) {
+    this.logger.debug(`Running exe: ${modId}, ${exePath}`)
+    const subscription = await this.subscriptionRepository.findOneByOrFail({ modId })
+    const release = await this.releaseRepository.findOneByOrFail({ subscription })
+
+    if (!release.enabled) {
+      throw new Error(`Mod is not enabled, please enable it first and try again`)
+    }
+
+    const path = await this.variablesService.replaceVariables(exePath)
+
+    execFile(path, [], { cwd: dirname(path) }, (error, stdout, stderr) => {
+      if (error) {
+        this.logger.error(`Error running exe: ${error}`)
+      }
+      if (stdout) {
+        this.logger.debug(`stdout: ${stdout}`)
+      }
+      if (stderr) {
+        this.logger.error(`stderr: ${stderr}`)
+      }
+    })
   }
 
   /**

--- a/src/main/manager/subscription.manager.ts
+++ b/src/main/manager/subscription.manager.ts
@@ -23,6 +23,7 @@ import { WriteDirectoryService } from '../services/write-directory.service'
 import { _7zip } from '../tools/7zip'
 import { LifecycleManager } from './lifecycle-manager.service'
 import { trackEvent } from '@aptabase/electron/main'
+import { execFile } from 'node:child_process'
 
 @Injectable()
 export class SubscriptionManager {
@@ -126,7 +127,8 @@ export class SubscriptionManager {
     this.logger.debug(`Saving subscription for mod ${modId}`)
     const subscription = await this.subscriptionRepository.save({
       modId: mod.id,
-      modName: mod.name
+      modName: mod.name,
+      exePath: latestRelease.exePath
     })
 
     this.logger.debug(`Saving latest release for mod ${modId}`)
@@ -213,6 +215,16 @@ export class SubscriptionManager {
       await this.fsService.openFolder(
         await this.writeDirectoryService.getWriteDirectoryForSubscription(subscription.id)
       )
+    }
+  }
+
+  async runExe(modId: string, exePath: string) {
+    this.logger.debug(`Running exe: ${modId}, ${exePath}`)
+    const subscription = await this.subscriptionRepository.findOneBy({ modId })
+    if (subscription) {
+      execFile(exePath, {
+        cwd: await this.writeDirectoryService.getWriteDirectoryForSubscription(subscription.id)
+      })
     }
   }
 

--- a/src/main/router.ts
+++ b/src/main/router.ts
@@ -134,7 +134,13 @@ export async function getAppWithRouter() {
       ),
       getRegistryUrl: trpc.procedure.query(
         async (): Promise<string> => app.get(SettingsManager).getRegistryUrl()
-      )
+      ),
+      runExe: trpc.procedure
+        .input(z.object({ modId: z.string(), exePath: z.string() }))
+        .mutation(
+          ({ input }): Promise<void> =>
+            app.get(SubscriptionManager).runExe(input.modId, input.exePath)
+        )
     })
   }
 }

--- a/src/main/router.ts
+++ b/src/main/router.ts
@@ -138,8 +138,7 @@ export async function getAppWithRouter() {
       runExe: trpc.procedure
         .input(z.object({ modId: z.string(), exePath: z.string() }))
         .mutation(
-          ({ input }): Promise<void> =>
-            app.get(SubscriptionManager).runExe(input.modId, input.exePath)
+          ({ input }): Promise<void> => app.get(LifecycleManager).runExe(input.modId, input.exePath)
         )
     })
   }

--- a/src/main/services/variables.service.test.ts
+++ b/src/main/services/variables.service.test.ts
@@ -1,0 +1,43 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { VariablesService } from './variables.service'
+import { SettingsManager } from '../manager/settings.manager'
+
+describe('VariablesService', () => {
+  let service: VariablesService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        VariablesService,
+        {
+          provide: SettingsManager,
+          useValue: {
+            getGameDir: vitest.fn().mockResolvedValue('/game/dir')
+          }
+        }
+      ]
+    }).compile()
+
+    service = module.get<VariablesService>(VariablesService)
+  })
+
+  it('retrieves variables and their values', async () => {
+    const variables = await service.getVariables()
+
+    expect(variables).toEqual({
+      DCS_USER_DIR: '/game/dir'
+    })
+  })
+
+  it('replaces variables in text with their values', async () => {
+    const result = await service.replaceVariables('Game: {{DCS_USER_DIR}}')
+
+    expect(result).toBe('Game: /game/dir')
+  })
+
+  it('throws an error if a variable is unknown', async () => {
+    await expect(service.replaceVariables('Unknown: {{UNKNOWN_VAR}}')).rejects.toThrow(
+      'Unknown Variable UNKNOWN_VAR in Unknown: {{UNKNOWN_VAR}}'
+    )
+  })
+})

--- a/src/main/services/variables.service.ts
+++ b/src/main/services/variables.service.ts
@@ -1,0 +1,41 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { SettingsManager } from '../manager/settings.manager'
+
+/**
+ * Service to handle variable replacements in strings.
+ */
+@Injectable()
+export class VariablesService {
+  @Inject(SettingsManager)
+  private settingsManager: SettingsManager
+
+  /**
+   * Retrieves the variables and their values.
+   * @returns {Promise<Record<string, string>>} A promise that resolves to an object containing variable names and their values.
+   */
+  async getVariables(): Promise<Record<string, string>> {
+    return {
+      DCS_USER_DIR: await this.settingsManager.getGameDir().then((dir) => dir.replace(/\\/g, '/'))
+    }
+  }
+
+  /**
+   * Replaces variables in the given text with their corresponding values.
+   * @param {string} text - The text containing variables to be replaced.
+   * @returns {Promise<string>} A promise that resolves to the text with variables replaced.
+   * @throws {Error} Throws an error if a variable is unknown.
+   */
+  async replaceVariables(text: string): Promise<string> {
+    const variables = await this.getVariables()
+
+    return text.replace(/{{(.*?)}}/g, (_, variable) => {
+      const variableValue = variables[variable]
+
+      if (!variableValue) {
+        throw new Error(`Unknown Variable ${variable} in ${text}`)
+      }
+
+      return variableValue
+    })
+  }
+}

--- a/src/renderer/src/container/subscriptions.tsx
+++ b/src/renderer/src/container/subscriptions.tsx
@@ -83,7 +83,7 @@ const SubscriptionRow: React.FC<{
         {exePath && (
           <ActionIcon
             size={'md'}
-            disabled={release.data?.status !== 'Completed'}
+            disabled={release.data?.status !== 'Completed' || !release.data?.enabled}
             variant={'subtle'}
             onClick={() => handleRunExe(modId, exePath)}
           >

--- a/src/renderer/src/container/subscriptions.tsx
+++ b/src/renderer/src/container/subscriptions.tsx
@@ -12,7 +12,7 @@ import {
   Tooltip
 } from '@mantine/core'
 import React from 'react'
-import { BiCheckbox, BiCheckboxChecked } from 'react-icons/bi'
+import { BiCheckbox, BiCheckboxChecked, BiPlay } from 'react-icons/bi'
 import { BsThreeDotsVertical } from 'react-icons/bs'
 import { client } from '../client'
 import { useFuse } from '../hooks/useFuse'
@@ -26,8 +26,9 @@ const SubscriptionRow: React.FC<{
   modId: string
   modName: string
   created: number
+  exePath: string | null
   onOpenSymlinksModal: (modId: string) => void
-}> = ({ modId, modName, created, onOpenSymlinksModal }) => {
+}> = ({ modId, modName, created, onOpenSymlinksModal, exePath }) => {
   const subscriptions = useSubscriptions()
   const navigate = useNavigate()
   const release = useSubscriptionRelease(modId)
@@ -54,21 +55,41 @@ const SubscriptionRow: React.FC<{
     }
   }
 
+  async function handleRunExe(modId: string, exePath: string) {
+    try {
+      await client.runExe.mutate({ modId, exePath })
+    } catch (err) {
+      showErrorNotification(err)
+    }
+  }
+
   return (
     <Table.Tr c={release.data?.enabled ? undefined : 'dimmed'}>
       <Table.Td>
-        <ActionIcon
-          size={'md'}
-          disabled={release.data?.status !== 'Completed'}
-          variant={'subtle'}
-          onClick={() => handleToggleMod(modId)}
-        >
-          {release.data?.enabled ? (
-            <BiCheckboxChecked size={'1.25em'} />
-          ) : (
-            <BiCheckbox size={'1.25em'} />
-          )}
-        </ActionIcon>
+        {!exePath && (
+          <ActionIcon
+            size={'md'}
+            disabled={release.data?.status !== 'Completed'}
+            variant={'subtle'}
+            onClick={() => handleToggleMod(modId)}
+          >
+            {release.data?.enabled ? (
+              <BiCheckboxChecked size={'1.25em'} />
+            ) : (
+              <BiCheckbox size={'1.25em'} />
+            )}
+          </ActionIcon>
+        )}
+        {exePath && (
+          <ActionIcon
+            size={'md'}
+            disabled={release.data?.status !== 'Completed'}
+            variant={'subtle'}
+            onClick={() => handleRunExe(modId, exePath)}
+          >
+            <BiPlay size={'1.25em'} />
+          </ActionIcon>
+        )}
       </Table.Td>
       <Table.Td>
         <Text>{modName}</Text>
@@ -166,6 +187,7 @@ export const Subscriptions: React.FC<SubscriptionsProps> = ({ onOpenSymlinksModa
                 modName={element.modName}
                 created={element.created}
                 onOpenSymlinksModal={onOpenSymlinksModal}
+                exePath={element.exePath}
               />
             ))}
           </Table.Tbody>

--- a/src/renderer/src/pages/registry-entry.page.tsx
+++ b/src/renderer/src/pages/registry-entry.page.tsx
@@ -16,7 +16,6 @@ import {
   Textarea,
   TextInput,
   Title,
-  Tooltip,
   TypographyStylesProvider
 } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
@@ -138,11 +137,9 @@ export const _RegistryEntryPage: React.FC<RegistryEntryPageProps> = ({ entry, la
               </Title>
               <AvatarGroup>
                 {entry.authors.map((it) => (
-                  <Tooltip key={it.name} label={it.name}>
-                    <Avatar src={it.url} alt={it.name}>
-                      {it.name.slice(0, 2)}
-                    </Avatar>
-                  </Tooltip>
+                  <Avatar key={it.name} src={it.url} alt={it.name}>
+                    {it.name.slice(0, 2)}
+                  </Avatar>
                 ))}
               </AvatarGroup>
             </Stack>


### PR DESCRIPTION
- Make Running EXE only work on enabled mods
- Support variable expansion

Example Registry file now:
```yaml
releasepage: https://github.com/akaAgar/briefing-room-for-dcs/releases/tag/release-202410.08-241008-171098-11240268625-1
name: Version 0.5.202410.08
tag: "0.5.202410.08"
version: "release-202410.08-241008-171098-11240268625-1"
date: 2024-10-08T12:00:00Z
exePath: '{{DCS_USER_DIR}}/Tools/BriefingRoom/BriefingRoomDesktop.exe'
assets:
  - source: https://github.com/DCS-BR-Tools/briefing-room-for-dcs/releases/download/release-202410.08-241008-171098-11240268625-1/BriefingRoom-V0.5.202410.08.zip/#/BriefingRoom-V0.5.202410.08
    target: '{{DCS_USER_DIR}}/Tools/BriefingRoom'
```


https://[dcs-mod-manager-registry.pages.dev/briefing-room/latest.json](https://dcs-mod-manager-registry.pages.dev/briefing-room/latest.json)