### PR TITLE
feat: add legal disclaimer modal and component

### DIFF
--- a/LEGAL_DISCLAIMER.md
+++ b/LEGAL_DISCLAIMER.md
@@ -1,0 +1,32 @@
+## Legal Disclaimer
+
+**DCS Dropzone Mod Manager (the "Software") is provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the authors or copyright holders be liable for any claim, damages, or other liability, whether in an action of contract, tort, or otherwise, arising from, out of, or in connection with the Software or the use or other dealings in the Software.**
+
+### Use at Your Own Risk
+
+- This software is a work-in-progress. Users are advised to use the Software at their own risk.
+- The authors are not responsible for any damage or loss of data that may occur as a result of using this Software.
+
+### Community Submitted Mods
+
+- Mods available through this software are submitted by the community and are not verified by the authors.
+- Users are advised to use community-submitted mods at their own risk. The authors are not responsible for any issues arising from the use of these mods.
+
+### No Affiliation with Eagle Dynamics
+
+- This project is not affiliated with, endorsed by, or in any way associated with Eagle Dynamics, the developers of DCS World.
+- The use of this Software and any modifications made to DCS World are done entirely at the user's own discretion and risk.
+
+### Modifications and Contributions
+
+- Contributions to this project are welcome. By submitting a pull request, you agree to license your contribution under the same license as this project.
+- Users are responsible for ensuring that their contributions do not infringe on any third-party rights.
+
+### Use of Aptabase
+
+- The Software uses Aptabase for anonymous usage analytics. This helps the authors improve the Software by collecting aggregate, non-identifiable data on how the Software is used.
+- No personal or sensitive information is collected. By using the Software, you consent to the collection of anonymous usage data as outlined by [Aptabase's privacy policy](https://aptabase.com/legal/privacy).
+
+### License
+
+- This software is licensed under the [MIT License](LICENSE). For more details, please refer to the LICENSE file included with the project.

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,12 +1,40 @@
 import { AppShell } from '@mantine/core'
-import { FC } from 'react'
 import { Route, Routes } from 'react-router-dom'
 import { AppHeader } from './app.header'
 import { AppNavbar } from './app.navbar'
 import { config } from './config'
 import { DcsFoldersModal } from './modal/dcs-folders.modal'
+import { useMount } from 'react-use'
+import { openConfirmModal } from '@mantine/modals'
+import { LegalDisclaimer } from '@renderer/components/legal-disclaimer'
+import { trackEvent } from '@aptabase/electron/renderer'
 
-export const App: FC = () => {
+export function App() {
+  useMount(() => {
+    const acceptedLegalDisclaimer = localStorage.getItem('accepted_legal')
+    if (!acceptedLegalDisclaimer) {
+      openConfirmModal({
+        closeOnCancel: false,
+        closeOnEscape: false,
+        closeOnClickOutside: false,
+        withCloseButton: false,
+        closeOnConfirm: true,
+        overlayProps: { blur: 10 },
+        size: 'xl',
+        children: <LegalDisclaimer />,
+        labels: { confirm: 'I Agree', cancel: 'Decline' },
+        onCancel: async () => {
+          await trackEvent('legal_disclaimer_declined')
+          window.close()
+        },
+        onConfirm: async () => {
+          await trackEvent('legal_disclaimer_accepted')
+          localStorage.setItem('accepted_legal', 'true')
+        }
+      })
+    }
+  })
+
   return (
     <AppShell
       header={{ height: 66 }}

--- a/src/renderer/src/components/legal-disclaimer.tsx
+++ b/src/renderer/src/components/legal-disclaimer.tsx
@@ -1,3 +1,8 @@
+import { Stack, TypographyStylesProvider } from '@mantine/core'
+import { marked } from 'marked'
+
+// Copied from "LEGAL)DISCLAIMER.md" in the root of the project, please keep in sync
+const disclaimer = `\
 ## Legal Disclaimer
 
 **DCS Dropzone Mod Manager (the "Software") is provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the authors or copyright holders be liable for any claim, damages, or other liability, whether in an action of contract, tort, or otherwise, arising from, out of, or in connection with the Software or the use or other dealings in the Software.**
@@ -6,6 +11,11 @@
 
 - This software is a work-in-progress. Users are advised to use the Software at their own risk.
 - The authors are not responsible for any damage or loss of data that may occur as a result of using this Software.
+
+### Community Submitted Mods
+
+- Mods available through this software are submitted by the community and are not verified by the authors.
+- Users are advised to use community-submitted mods at their own risk. The authors are not responsible for any issues arising from the use of these mods.
 
 ### No Affiliation with Eagle Dynamics
 
@@ -17,11 +27,26 @@
 - Contributions to this project are welcome. By submitting a pull request, you agree to license your contribution under the same license as this project.
 - Users are responsible for ensuring that their contributions do not infringe on any third-party rights.
 
-### Community Submitted Mods
+### Use of Aptabase
 
-- Mods available through this software are submitted by the community and are not verified by the authors.
-- Users are advised to use community-submitted mods at their own risk. The authors are not responsible for any issues arising from the use of these mods.
+- The Software uses Aptabase for anonymous usage analytics. This helps the authors improve the Software by collecting aggregate, non-identifiable data on how the Software is used.
+- No personal or sensitive information is collected. By using the Software, you consent to the collection of anonymous usage data as outlined by [Aptabase's privacy policy](https://aptabase.com/legal/privacy).
 
 ### License
 
 - This software is licensed under the [MIT License](LICENSE). For more details, please refer to the LICENSE file included with the project.
+`
+
+export function LegalDisclaimer() {
+  return (
+    <Stack>
+      <TypographyStylesProvider>
+        <div
+          dangerouslySetInnerHTML={{
+            __html: marked.parse(disclaimer)
+          }}
+        />
+      </TypographyStylesProvider>
+    </Stack>
+  )
+}


### PR DESCRIPTION
- Implemented a new LegalDisclaimer component to display the disclaimer text.
- Integrated a modal that prompts users to accept the legal disclaimer on app mount.
- Tracked events for acceptance or decline of the disclaimer using Aptabase.
- Renamed LEGAL.md to LEGAL_DISCLAIMER.md for clarity.
- Updated App component to use hooks for managing the disclaimer modal logic.


This pull request includes significant updates to the legal disclaimer and the introduction of a new legal disclaimer modal in the application. The most important changes include renaming and updating the legal disclaimer file, adding a new modal to display the legal disclaimer on application startup, and integrating usage analytics with Aptabase.

Updates to the legal disclaimer:

* [`LEGAL_DISCLAIMER.md`](diffhunk://#diff-5a9f7fa883018d803fcc23f3f7ff92223a04673f3132128cb080b990259b3853R10-R14): Renamed from `LEGAL.md` and updated to include sections on community-submitted mods and the use of Aptabase for anonymous usage analytics. [[1]](diffhunk://#diff-5a9f7fa883018d803fcc23f3f7ff92223a04673f3132128cb080b990259b3853R10-R14) [[2]](diffhunk://#diff-5a9f7fa883018d803fcc23f3f7ff92223a04673f3132128cb080b990259b3853L20-R28)

New legal disclaimer modal:

* [`src/renderer/src/App.tsx`](diffhunk://#diff-a9d1f8b421da343d1839cd3d03a144a079ed3863384f0fab015c96f7898a28abL2-L9): Added logic to display a modal with the legal disclaimer on application startup if the user has not previously accepted it.
* [`src/renderer/src/components/legal-disclaimer.tsx`](diffhunk://#diff-cbe2efa8f8f8d51ce4c46db624fdea4d06b60aa6237a70e078e64a6b2f59554cR1-R52): Created a new component for displaying the legal disclaimer content within the modal.