### PR TITLE
fix: adjust markdown rendering and layout for registry entry page

### DIFF
--- a/src/renderer/src/assets/index.css
+++ b/src/renderer/src/assets/index.css
@@ -2,6 +2,10 @@
   margin-top: var(--mantine-spacing-md) !important;
 }
 
+.readme pre code {
+  background-color: unset;
+}
+
 @font-face {
   font-family: 'Doctor Glitch';
   src:

--- a/src/renderer/src/pages/registry-entry.page.tsx
+++ b/src/renderer/src/pages/registry-entry.page.tsx
@@ -63,14 +63,14 @@ export const _RegistryEntryPage: React.FC<RegistryEntryPageProps> = ({ entry }) 
         </Anchor>
         <Anchor size={'sm'}>{entry.name}</Anchor>
       </Breadcrumbs>
-      <TypographyStylesProvider className={'readme'} pl={'xs'}>
+      <TypographyStylesProvider className={'readme'} pr={300} pb={'xl'}>
         <div
           dangerouslySetInnerHTML={{
             __html: marked.parse(atob(entry.content))
           }}
         />
       </TypographyStylesProvider>
-      <AppShell.Aside>
+      <AppShell.Aside w={300}>
         <ScrollArea>
           <Stack p={'md'}>
             <Stack gap={'xs'}>


### PR DESCRIPTION
- Updated TypographyStylesProvider to correct padding and margin.
- Set width for AppShell.Aside to improve layout consistency.
- Modified CSS to unset background color for code blocks within .readme.

<img width="1203" alt="image" src="https://github.com/user-attachments/assets/ab4ec9f2-0fc1-4082-b23c-968b33cbc337" />

This pull request includes changes to the styling and layout of the `RegistryEntryPage` in the renderer. The most important changes include updates to the CSS for code blocks within the README and adjustments to the layout properties of the `TypographyStylesProvider` and `AppShell.Aside` components.

Styling updates:

* [`src/renderer/src/assets/index.css`](diffhunk://#diff-578ec10beff6e4006ac5d77775b6b25680215ab1df6ee5855b2531ee0073c125R5-R8): Added CSS rules to unset the background color for code blocks within the README.

Layout adjustments:

* [`src/renderer/src/pages/registry-entry.page.tsx`](diffhunk://#diff-fe9477d0ffe49f2aa9709b83d7f1d41b62d9a8cd83bdd9d903f6ea76169eb93dL66-R73): Modified the `TypographyStylesProvider` to use a right padding of 300 and bottom padding of 'xl'.
* [`src/renderer/src/pages/registry-entry.page.tsx`](diffhunk://#diff-fe9477d0ffe49f2aa9709b83d7f1d41b62d9a8cd83bdd9d903f6ea76169eb93dL66-R73): Updated the `AppShell.Aside` component to have a fixed width of 300.