### PR TITLE
fix: handle non-existent write directory

### DIFF
--- a/src/main/manager/subscription.manager.ts
+++ b/src/main/manager/subscription.manager.ts
@@ -13,7 +13,7 @@ import { Log } from '../utils/log'
 import { getReleaseAsset } from '../utils/get-release-asset'
 import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
-import { existsSync, readdirSync, ensureDirSync, rmdir } from 'fs-extra'
+import { pathExists, readdirSync, ensureDirSync, rmdir } from 'fs-extra'
 import { AssetTaskStatus } from '../schemas/release-asset-task.schema'
 
 export type SubscriptionReleaseState = {
@@ -196,7 +196,7 @@ export class SubscriptionManager implements OnApplicationBootstrap {
 
     const modDir = await this.writeDirectoryService.getWriteDirectoryForSubscription(subscription)
 
-    if (existsSync(modDir)) {
+    if (await pathExists(modDir)) {
       this.logger.debug(`Deleting write directory for mod ${modId}`)
       await rmdir(modDir, { recursive: true })
     }
@@ -230,7 +230,7 @@ export class SubscriptionManager implements OnApplicationBootstrap {
   async removeOrphanedSubscriptionsAndReleases() {
     const writeDirectory = await this.writeDirectoryService.getWriteDirectory()
 
-    if (!existsSync(writeDirectory)) return
+    if (!(await pathExists(writeDirectory))) return
 
     const foldersInWriteDirectory = readdirSync(writeDirectory, { withFileTypes: true }).filter(
       (it) => it.isDirectory()

--- a/src/main/manager/subscription.manager.ts
+++ b/src/main/manager/subscription.manager.ts
@@ -13,7 +13,7 @@ import { Log } from '../utils/log'
 import { getReleaseAsset } from '../utils/get-release-asset'
 import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
-import { existsSync, readdirSync, ensureDirSync, rmdir, pathExistsSync } from 'fs-extra'
+import { existsSync, readdirSync, ensureDirSync, rmdir } from 'fs-extra'
 import { AssetTaskStatus } from '../schemas/release-asset-task.schema'
 
 export type SubscriptionReleaseState = {
@@ -230,7 +230,7 @@ export class SubscriptionManager implements OnApplicationBootstrap {
   async removeOrphanedSubscriptionsAndReleases() {
     const writeDirectory = await this.writeDirectoryService.getWriteDirectory()
 
-    if (!pathExistsSync(writeDirectory)) return
+    if (!existsSync(writeDirectory)) return
 
     const foldersInWriteDirectory = readdirSync(writeDirectory, { withFileTypes: true }).filter(
       (it) => it.isDirectory()

--- a/src/main/manager/subscription.manager.ts
+++ b/src/main/manager/subscription.manager.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common'
-import { ensureDirSync, rmdir } from 'fs-extra'
 import { ProgressLabel } from '../../lib/types'
 import { FsService } from '../services/fs.service'
 import { RegistryService } from '../services/registry.service'
@@ -14,7 +13,7 @@ import { Log } from '../utils/log'
 import { getReleaseAsset } from '../utils/get-release-asset'
 import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
-import { existsSync, readdirSync } from 'node:fs'
+import { existsSync, readdirSync, ensureDirSync, rmdir, pathExistsSync } from 'fs-extra'
 import { AssetTaskStatus } from '../schemas/release-asset-task.schema'
 
 export type SubscriptionReleaseState = {
@@ -230,6 +229,9 @@ export class SubscriptionManager implements OnApplicationBootstrap {
   @Log()
   async removeOrphanedSubscriptionsAndReleases() {
     const writeDirectory = await this.writeDirectoryService.getWriteDirectory()
+
+    if (!pathExistsSync(writeDirectory)) return
+
     const foldersInWriteDirectory = readdirSync(writeDirectory, { withFileTypes: true }).filter(
       (it) => it.isDirectory()
     )


### PR DESCRIPTION
Ensure the function `removeOrphanedSubscriptionsAndReleases` checks for the existence of the write directory before proceeding. This prevents errors when the directory does not exist.

Closes: #45
Closes: #42

This pull request includes changes to the `SubscriptionManager` class in `src/main/manager/subscription.manager.ts` to enhance directory management and ensure proper cleanup of directories. The most important changes include the replacement of methods from node:fs to use the `fs-extra` library and a check for the existence of the write directory before proceeding with operations.

Enhancements to directory management:

* [`src/main/manager/subscription.manager.ts`](diffhunk://#diff-3361f9788be7f908479c0220a7990b3ba13c2d1b1d9c49c03b562d89def26c95L2): Replaced `fs` methods with `fs-extra` methods to ensure directory operations are properly handled. [[1]](diffhunk://#diff-3361f9788be7f908479c0220a7990b3ba13c2d1b1d9c49c03b562d89def26c95L2) [[2]](diffhunk://#diff-3361f9788be7f908479c0220a7990b3ba13c2d1b1d9c49c03b562d89def26c95L17-R16)
* [`src/main/manager/subscription.manager.ts`](diffhunk://#diff-3361f9788be7f908479c0220a7990b3ba13c2d1b1d9c49c03b562d89def26c95R232-R234): Added a check using `pathExistsSync` to verify the existence of the write directory before attempting to read its contents.