### PR TITLE
Fix/catch errors on failed tasks

### DIFF
--- a/src/main/manager/subscription.manager.ts
+++ b/src/main/manager/subscription.manager.ts
@@ -27,6 +27,7 @@ export type SubscriptionReleaseState = {
   isLatest: boolean
   latest?: string
   isReady: boolean
+  isFailed: boolean
 }
 
 export type SubscriptionWithState = {
@@ -116,7 +117,8 @@ export class SubscriptionManager implements OnApplicationBootstrap {
       isReady: taskStatuses.every((it) => it === AssetTaskStatus.COMPLETED),
       exePath: installed.exePath,
       isLatest: installed.version === latest?.version || true,
-      latest: latest?.version
+      latest: latest?.version,
+      isFailed: taskStatuses.some((it) => it === AssetTaskStatus.FAILED)
     }
   }
 

--- a/src/main/services/release.service.ts
+++ b/src/main/services/release.service.ts
@@ -135,17 +135,17 @@ export class ReleaseService {
       .then((it) => it?.toJSON())
   }
 
-  async findPendingAssetTaskSortedBySequence(): Promise<AssetTask | undefined> {
-    return this.assetTasks
-      .findOne({ status: AssetTaskStatus.PENDING })
-      .sort({ sequence: 1, createdAt: 1 })
-      .exec()
-      .then((it) => it?.toJSON())
-  }
-
   async deleteBySubscriptionId(id: string) {
     await this.assetTasks.deleteMany({ subscriptionId: id }).exec()
     await this.releaseAssets.deleteMany({ subscriptionId: id }).exec()
     await this.releases.deleteOne({ subscriptionId: id }).exec()
+  }
+
+  async findAssetTasksByAssetId(id: string): Promise<AssetTask[]> {
+    return this.assetTasks
+      .find({ releaseAssetId: id })
+      .sort({ sequence: 1 })
+      .exec()
+      .then((it) => it.map((it) => it.toJSON()))
   }
 }

--- a/src/main/services/subscription.service.ts
+++ b/src/main/services/subscription.service.ts
@@ -2,19 +2,16 @@ import { Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 import { Subscription } from '../schemas/subscription.schema'
 import { Model } from 'mongoose'
-import { Log } from '../utils/log'
 
 @Injectable()
 export class SubscriptionService {
   @InjectModel(Subscription.name)
   private readonly subscriptions: Model<Subscription>
 
-  @Log()
   async deleteById(id: string): Promise<void> {
     await this.subscriptions.deleteOne({ id }).exec()
   }
 
-  @Log()
   async findById(id: string): Promise<Subscription | undefined> {
     return this.subscriptions
       .findOne({ id })
@@ -22,7 +19,6 @@ export class SubscriptionService {
       .then((it) => it?.toJSON() ?? undefined)
   }
 
-  @Log()
   async findAll(): Promise<Subscription[]> {
     return this.subscriptions
       .find()
@@ -31,7 +27,6 @@ export class SubscriptionService {
       .then((it) => it.map((it) => it.toJSON()))
   }
 
-  @Log()
   async findByIdOrThrow(id: string): Promise<Subscription> {
     return this.subscriptions
       .findOne({ id })
@@ -40,7 +35,6 @@ export class SubscriptionService {
       .then((it) => it?.toJSON() ?? undefined)
   }
 
-  @Log()
   async findByModId(modId: string): Promise<Subscription | undefined> {
     return this.subscriptions
       .findOne({ modId })
@@ -48,7 +42,6 @@ export class SubscriptionService {
       .then((it) => it?.toJSON() ?? undefined)
   }
 
-  @Log()
   async findByModIdOrThrow(modId: string): Promise<Subscription> {
     return this.subscriptions
       .findOne({ modId })
@@ -57,12 +50,6 @@ export class SubscriptionService {
       .then((it) => it.toJSON())
   }
 
-  @Log()
-  async deleteByModId(modId: string): Promise<void> {
-    await this.subscriptions.deleteOne({ modId }).exec()
-  }
-
-  @Log()
   async save(subscription: Subscription): Promise<Subscription> {
     await this.subscriptions
       .updateOne({ modId: subscription.modId }, subscription, { upsert: true })

--- a/src/main/utils/find-first-pending-task.test.ts
+++ b/src/main/utils/find-first-pending-task.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { findFirstPendingTask } from './find-first-pending-task'
+import { AssetTaskStatus, AssetTaskType } from '../schemas/release-asset-task.schema'
+
+describe('findFirstPending', () => {
+  it('should return the first pending task with sequence 1', () => {
+    const tasks = [
+      { id: '1', sequence: 1, status: AssetTaskStatus.PENDING, type: AssetTaskType.DOWNLOAD },
+      { id: '2', sequence: 2, status: AssetTaskStatus.PENDING, type: AssetTaskType.EXTRACT }
+    ]
+    const result = findFirstPendingTask(tasks)
+    expect(result).toEqual(tasks[0])
+  })
+
+  it('should return the first pending task with sequence greater than 1 if previous task is completed', () => {
+    const tasks = [
+      { id: '1', sequence: 1, status: AssetTaskStatus.COMPLETED, type: AssetTaskType.DOWNLOAD },
+      { id: '2', sequence: 2, status: AssetTaskStatus.PENDING, type: AssetTaskType.EXTRACT }
+    ]
+    const result = findFirstPendingTask(tasks)
+    expect(result).toEqual(tasks[1])
+  })
+
+  it('should return undefined if no tasks are pending', () => {
+    const tasks = [
+      { id: '1', sequence: 1, status: AssetTaskStatus.COMPLETED, type: AssetTaskType.DOWNLOAD },
+      { id: '2', sequence: 2, status: AssetTaskStatus.COMPLETED, type: AssetTaskType.EXTRACT }
+    ]
+    const result = findFirstPendingTask(tasks)
+    expect(result).toBeUndefined()
+  })
+
+  it('should return undefined if no tasks exist', () => {
+    const tasks = []
+    const result = findFirstPendingTask(tasks)
+    expect(result).toBeUndefined()
+  })
+
+  it('should return undefined if the first task is not pending and no previous task is completed', () => {
+    const tasks = [
+      { id: '1', sequence: 1, status: AssetTaskStatus.FAILED, type: AssetTaskType.DOWNLOAD },
+      { id: '2', sequence: 2, status: AssetTaskStatus.PENDING, type: AssetTaskType.EXTRACT }
+    ]
+    const result = findFirstPendingTask(tasks)
+    expect(result).toBeUndefined()
+  })
+})

--- a/src/main/utils/find-first-pending-task.ts
+++ b/src/main/utils/find-first-pending-task.ts
@@ -1,0 +1,21 @@
+import { AssetTask } from '../schemas/release-asset-task.schema'
+
+export function findFirstPendingTask<T extends Pick<AssetTask, 'status' | 'sequence'>>(
+  tasks: T[]
+): T | undefined {
+  let previousTask: T | undefined
+
+  for (const task of tasks) {
+    if (task.status === 'PENDING') {
+      if (previousTask?.status === 'COMPLETED') {
+        return task
+      }
+      if (!previousTask) {
+        return task
+      }
+    }
+    previousTask = task
+  }
+
+  return undefined
+}

--- a/src/renderer/src/components/subscription-row.tsx
+++ b/src/renderer/src/components/subscription-row.tsx
@@ -17,6 +17,7 @@ export type SubscriptionRowProps = {
   onRunExe?: () => void
   onUnsubscribe: () => void
   isReady: boolean
+  isFailed: boolean
   stateLabel: string
   progress: number
 }
@@ -62,7 +63,7 @@ export function SubscriptionRow(props: SubscriptionRowProps) {
         </Group>
       </Table.Td>
       <Table.Td>
-        {!props.isReady ? (
+        {!props.isReady && !props.isFailed ? (
           <Tooltip label={props.stateLabel}>
             <Progress.Root size="lg">
               <Progress.Section value={props.progress} striped animated>

--- a/src/renderer/src/container/subscriptions.tsx
+++ b/src/renderer/src/container/subscriptions.tsx
@@ -16,7 +16,7 @@ export function Subscriptions({ onOpenSymlinksModal }: SubscriptionsProps) {
   const { results, search, setSearch } = useFuse(subscriptions.data || [], '', ['modId', 'modName'])
 
   useEffect(() => {
-    if (subscriptions.data?.some(({ state }) => state.progress !== 100)) {
+    if (subscriptions.data?.some(({ state }) => state.progress !== 100 && !state.isFailed)) {
       setTimeout(() => subscriptions.mutate(), 500)
     }
   }, [subscriptions.data])
@@ -110,6 +110,7 @@ export function Subscriptions({ onOpenSymlinksModal }: SubscriptionsProps) {
                     ? () => state.exePath && handleRunExe(subscription.modId, state.exePath)
                     : undefined
                 }
+                isFailed={state.isFailed}
               />
             ))}
           </Table.Tbody>


### PR DESCRIPTION
This pull request includes several changes to improve task management, error handling, and code simplification. The most important changes include adding a new `isFailed` state to subscription management, enhancing task checking logic, and simplifying the `SubscriptionService` class by removing unnecessary logging.

Enhancements to subscription management:

* [`src/main/manager/subscription.manager.ts`](diffhunk://#diff-3361f9788be7f908479c0220a7990b3ba13c2d1b1d9c49c03b562d89def26c95R29): Added `isFailed` property to `SubscriptionReleaseState` and updated the `SubscriptionManager` class to include `isFailed` status. [[1]](diffhunk://#diff-3361f9788be7f908479c0220a7990b3ba13c2d1b1d9c49c03b562d89def26c95R29) [[2]](diffhunk://#diff-3361f9788be7f908479c0220a7990b3ba13c2d1b1d9c49c03b562d89def26c95L118-R120)

Improvements to task management:

* [`src/main/manager/task.manager.ts`](diffhunk://#diff-f8439d6ec4a21b5f7170dccd77f817eced92bf998e3b749cd09b72ee3add0877L64-R88): Refined the `checkForPendingTasks` method to use the new `findFirstPendingTask` utility for better task selection.
* [`src/main/services/release.service.ts`](diffhunk://#diff-9d894157462cce57fee98634c2c874b2d98a731e4130731e6356d056cebbd16cL138-R150): Removed the `findPendingAssetTaskSortedBySequence` method and added `findAssetTasksByAssetId` method for more efficient task retrieval.

Code simplification:

* [`src/main/services/subscription.service.ts`](diffhunk://#diff-a8e5d48db7f62bb0528716589222c6632a23df8bf151967929bc1dce18bc3ca5L5-L25): Removed the `@Log` decorator from several methods to simplify the `SubscriptionService` class. [[1]](diffhunk://#diff-a8e5d48db7f62bb0528716589222c6632a23df8bf151967929bc1dce18bc3ca5L5-L25) [[2]](diffhunk://#diff-a8e5d48db7f62bb0528716589222c6632a23df8bf151967929bc1dce18bc3ca5L34) [[3]](diffhunk://#diff-a8e5d48db7f62bb0528716589222c6632a23df8bf151967929bc1dce18bc3ca5L43-L51) [[4]](diffhunk://#diff-a8e5d48db7f62bb0528716589222c6632a23df8bf151967929bc1dce18bc3ca5L60-L65)

New utility and tests:

* [`src/main/utils/find-first-pending-task.ts`](diffhunk://#diff-c33b045a8a8f0c9498b6df41444cbd2c62feac504ecb979c08c78e4eba5635b1R1-R21): Added a new utility function `findFirstPendingTask` to find the first pending task.
* [`src/main/utils/find-first-pending-task.test.ts`](diffhunk://#diff-60c9689244a298fb66cb842a3e3f8e12ee90f459270e2da8fe56f13ceeedaeb0R1-R47): Added tests for the `findFirstPendingTask` utility function.

These changes improve the robustness of the subscription and task management system by not just picking any next pending task but ensuring that the last task for the new pending task was completed successfully.