### PR TITLE
fix(main): correct logic for determining if installed version is latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@nestjs/common": "^10.3.10",
         "@nestjs/core": "^10.3.10",
         "@nestjs/mongoose": "^10.1.0",
-        "@nestjs/schedule": "^4.1.0",
         "@nestjs/testing": "^10.4.15",
         "@nestjs/typeorm": "^10.0.2",
         "@trpc/client": "^10.45.2",
@@ -90,7 +89,7 @@
         "vitest": "2.0.5"
       },
       "engines": {
-        "node": "20.16.0"
+        "node": "^20.16.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2256,20 +2255,6 @@
         "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "mongoose": "^6.0.2 || ^7.0.0 || ^8.0.0",
         "rxjs": "^7.0.0"
-      }
-    },
-    "node_modules/@nestjs/schedule": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-4.1.0.tgz",
-      "integrity": "sha512-WEc96WTXZW+VI/Ng+uBpiBUwm6TWtAbQ4RKWkfbmzKvmbRGzA/9k/UyAWDS9k0pp+ZcbC+MaZQtt7TjQHrwX6g==",
-      "license": "MIT",
-      "dependencies": {
-        "cron": "3.1.7",
-        "uuid": "10.0.0"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/@nestjs/testing": {
@@ -4709,12 +4694,6 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
       "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/luxon": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
-      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
       "license": "MIT"
     },
     "node_modules/@types/minimatch": {
@@ -7503,16 +7482,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/cron": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/cron/-/cron-3.1.7.tgz",
-      "integrity": "sha512-tlBg7ARsAMQLzgwqVxy8AZl/qlTc5nibqYwtNGoCrd+cV+ugI+tvZC1oT/8dFH8W455YrywGykx/KMmAqOr7Jw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/luxon": "~3.4.0",
-        "luxon": "~3.4.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -11784,15 +11753,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/luxon": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
-      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/magic-string": {
@@ -19760,19 +19720,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Flying Dice",
   "private": true,
   "engines": {
-    "node": "20.16.0"
+    "node": "^20.16.0"
   },
   "release": {
     "branches": [
@@ -64,7 +64,6 @@
     "@nestjs/common": "^10.3.10",
     "@nestjs/core": "^10.3.10",
     "@nestjs/mongoose": "^10.1.0",
-    "@nestjs/schedule": "^4.1.0",
     "@nestjs/testing": "^10.4.15",
     "@nestjs/typeorm": "^10.0.2",
     "@trpc/client": "^10.45.2",

--- a/src/main/app.module.ts
+++ b/src/main/app.module.ts
@@ -5,7 +5,6 @@ import {
   OnApplicationBootstrap,
   OnApplicationShutdown
 } from '@nestjs/common'
-import { ScheduleModule } from '@nestjs/schedule'
 import { LifecycleManager } from './manager/lifecycle-manager.service'
 import { SettingsManager } from './manager/settings.manager'
 import { SubscriptionManager } from './manager/subscription.manager'
@@ -32,7 +31,6 @@ import Aigle from 'aigle'
 
 @Module({
   imports: [
-    ScheduleModule.forRoot(),
     MongooseModule.forRootAsync({
       useFactory: MongooseFactory.factory
     }),

--- a/src/main/manager/subscription.manager.ts
+++ b/src/main/manager/subscription.manager.ts
@@ -115,7 +115,7 @@ export class SubscriptionManager implements OnApplicationBootstrap {
       currentTaskLabel: assetTasks.find((it) => it.status === AssetTaskStatus.IN_PROGRESS)?.label,
       isReady: taskStatuses.every((it) => it === AssetTaskStatus.COMPLETED),
       exePath: installed.exePath,
-      isLatest: installed.version === latest?.version || true,
+      isLatest: latest?.version ? installed.version === latest?.version : true,
       latest: latest?.version,
       isFailed: taskStatuses.some((it) => it === AssetTaskStatus.FAILED)
     }


### PR DESCRIPTION
This pull request includes several updates to the dependencies and codebase cleanup in the `package.json` file and related source files. The most important changes include updating the Node.js engine version specification, removing the `@nestjs/schedule` dependency, and refining a condition in the `SubscriptionManager` class.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L9-R9): Updated the Node.js engine version specification to use a version range (`^20.16.0`) instead of a fixed version (`20.16.0`).
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L67): Removed the `@nestjs/schedule` dependency.

Codebase cleanup:

* [`src/main/app.module.ts`](diffhunk://#diff-8a9aa86f8d2cc5f2f50bd4419c2de0437dfc0e547450b78aa085709cde0f749aL8): Removed the import statement for `ScheduleModule` from `@nestjs/schedule`.
* [`src/main/app.module.ts`](diffhunk://#diff-8a9aa86f8d2cc5f2f50bd4419c2de0437dfc0e547450b78aa085709cde0f749aL35): Removed the `ScheduleModule.forRoot()` call from the module imports.

Bug fix:

* [`src/main/manager/subscription.manager.ts`](diffhunk://#diff-3361f9788be7f908479c0220a7990b3ba13c2d1b1d9c49c03b562d89def26c95L118-R118): Refined the condition to check if the installed version is the latest by properly handling the case when `latest?.version` is undefined.