### PR TITLE
Mod dependencies and by extension mod packs

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -44,7 +44,7 @@ export type EntryIndexAuthorsItem = {
   url?: string
 }
 
-export interface EntryIndex {
+interface EntryIndexBase {
   authors: EntryIndexAuthorsItem[]
   /** The category of the mod, this is used to group mods in the mod browser */
   category?: string
@@ -63,10 +63,23 @@ export interface EntryIndex {
   name?: string
   /** The tags of the mod, these are used to filter mods in the mod browser */
   tags: string[]
-  /** Mod Ids this mod is dependent on */
-  dependencies?: string[]
+
   /** The versions of the mod */
   versions: EntryIndexVersionsItem[]
+}
+
+export interface EntryIndex extends EntryIndexBase {
+  /** Mod Ids this mod is dependent on */
+  dependencies?: string[]
+}
+
+export interface EntryIndexSimple {
+  id: string
+  name: string
+}
+
+export interface EntryIndexHydrated extends EntryIndexBase {
+  dependencies?: EntryIndexSimple[]
 }
 
 export type RegistryIndexItemAuthorsItem = {

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -63,6 +63,8 @@ export interface EntryIndex {
   name?: string
   /** The tags of the mod, these are used to filter mods in the mod browser */
   tags: string[]
+  /** Mod Ids this mod is dependent on */
+  dependencies?: string[]
   /** The versions of the mod */
   versions: EntryIndexVersionsItem[]
 }

--- a/src/main/manager/lifecycle-manager.service.ts
+++ b/src/main/manager/lifecycle-manager.service.ts
@@ -49,15 +49,18 @@ export class LifecycleManager {
    * If the mod is enabled, it will be disabled
    * If the mod is disabled, it will be enabled
    */
-  async toggleMod(modId: string): Promise<void> {
+  async toggleMod(modId: string, enableOnly: boolean | undefined): Promise<boolean> {
     const { release } = await this.getSubscriptionWithReleaseOrThrow(modId)
     this.logger.debug(`Toggling mod: ${modId} which is currently ${release.enabled}`)
-    if (release.enabled) {
+    if (release.enabled && enableOnly !== true) {
       this.logger.debug(`Disabling mod: ${modId}`)
       await this.disableMod(modId)
+      return false
     } else {
+      if (enableOnly === true && release.enabled) return true
       this.logger.debug(`Enabling mod: ${modId}`)
       await this.enableMod(modId)
+      return true
     }
   }
 

--- a/src/main/manager/subscription.manager.ts
+++ b/src/main/manager/subscription.manager.ts
@@ -169,7 +169,8 @@ export class SubscriptionManager implements OnApplicationBootstrap {
       id: randomUUID(),
       modId: mod.id,
       modName: mod.name!,
-      created: Date.now()
+      created: Date.now(),
+      dependencies: mod.dependencies || []
     }
     const release: Release = {
       id: randomUUID(),

--- a/src/main/router.ts
+++ b/src/main/router.ts
@@ -43,9 +43,10 @@ export function getAppRouter(moduleRef: ModuleRef) {
     }),
     // Enable/Disable Toggle
     toggleMod: trpc.procedure
-      .input(z.object({ modId: z.string() }))
+      .input(z.object({ modId: z.string(), enableOnly: z.boolean().optional() }))
       .mutation(
-        async ({ input }): Promise<void> => moduleRef.get(LifecycleManager).toggleMod(input.modId)
+        async ({ input }): Promise<boolean> =>
+          moduleRef.get(LifecycleManager).toggleMod(input.modId, input.enableOnly)
       ),
     getModAssets: trpc.procedure
       .input(z.object({ modId: z.string() }))

--- a/src/main/schemas/subscription.schema.ts
+++ b/src/main/schemas/subscription.schema.ts
@@ -1,4 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose'
+import { EntryIndexSimple } from '../../lib/client'
 
 @Schema({ timestamps: true })
 export class Subscription {
@@ -7,6 +8,9 @@ export class Subscription {
 
   @Prop({ required: true, index: true })
   modId: string
+
+  @Prop({ required: false, index: true })
+  dependencies: EntryIndexSimple[]
 
   @Prop({ required: true })
   modName: string

--- a/src/main/services/subscription.service.test.ts
+++ b/src/main/services/subscription.service.test.ts
@@ -32,7 +32,8 @@ describe('SubscriptionService', () => {
     id: 'test-subscription',
     modId: 'test-mod',
     modName: 'Test Subscription',
-    created: Date.now()
+    created: Date.now(),
+    dependencies: []
   }
 
   beforeAll(async () => {

--- a/src/renderer/src/components/subscription-row.tsx
+++ b/src/renderer/src/components/subscription-row.tsx
@@ -1,18 +1,6 @@
-import {
-  ActionIcon,
-  Anchor,
-  Group,
-  Menu,
-  Progress,
-  Stack,
-  Table,
-  Text,
-  Tooltip
-} from '@mantine/core'
-import { useState } from 'react'
+import { ActionIcon, Group, Menu, Progress, Stack, Table, Text, Tooltip } from '@mantine/core'
 import { BiCheckbox, BiCheckboxChecked, BiPlay } from 'react-icons/bi'
 import { BsThreeDotsVertical } from 'react-icons/bs'
-import { useNavigate } from 'react-router-dom'
 import { EntryIndexSimple } from 'src/lib/client'
 
 function SubscriptionStatusColumn(props: {
@@ -111,6 +99,7 @@ export type SubscriptionRowProps = {
   onOpenInExplorer: () => void
   onToggleMod: () => void
   onUpdate: () => void
+  onFixMissingDeps: () => void
   onRunExe?: () => void
   onUnsubscribe: () => void
   isReady: boolean
@@ -182,6 +171,11 @@ export function SubscriptionRow(props: SubscriptionRowProps) {
             {!props.isLatest && <Menu.Item onClick={props.onUpdate}>Update</Menu.Item>}
             {props.isReady && props.errors && props.isLatest && (
               <Menu.Item onClick={props.onUpdate}>Resubscribe</Menu.Item>
+            )}
+            {props.isReady && props.missingDeps.length > 0 && (
+              <Menu.Item onClick={props.onFixMissingDeps}>
+                Subscribe to missing Dependencies
+              </Menu.Item>
             )}
             <Menu.Item
               onClick={() => props.onToggleMod()}

--- a/src/renderer/src/components/subscription-row.tsx
+++ b/src/renderer/src/components/subscription-row.tsx
@@ -1,6 +1,19 @@
-import { ActionIcon, Group, Menu, Progress, Stack, Table, Text, Tooltip } from '@mantine/core'
+import {
+  ActionIcon,
+  Anchor,
+  Group,
+  Menu,
+  Progress,
+  Stack,
+  Table,
+  Text,
+  Tooltip
+} from '@mantine/core'
+import { useState } from 'react'
 import { BiCheckbox, BiCheckboxChecked, BiPlay } from 'react-icons/bi'
 import { BsThreeDotsVertical } from 'react-icons/bs'
+import { useNavigate } from 'react-router-dom'
+import { EntryIndexSimple } from 'src/lib/client'
 
 function SubscriptionStatusColumn(props: {
   isLatest: boolean
@@ -10,6 +23,7 @@ function SubscriptionStatusColumn(props: {
   latestVersion?: string
   progress: number
   errors: string[]
+  missingDeps: EntryIndexSimple[]
 }) {
   if (props.isReady && props.errors.length > 0) {
     const errors = props.errors.map((error, index) => (
@@ -23,6 +37,30 @@ function SubscriptionStatusColumn(props: {
         <Tooltip label={<Stack gap={2}>{errors}</Stack>}>
           <Text fw={'bold'} c={'red'} size={'sm'}>
             Error
+          </Text>
+        </Tooltip>
+      </Table.Td>
+    )
+  }
+
+  if (props.isReady && props.missingDeps.length > 0) {
+    return (
+      <Table.Td>
+        <Tooltip
+          multiline
+          withinPortal={false}
+          label={
+            <Stack gap={'xs'}>
+              <Text size={'sm'}>Missing Dependencies:</Text>
+              {props.missingDeps.map((dependency) => (
+                <Text key={dependency.id}>- {dependency.name || dependency.id}</Text>
+              ))}
+            </Stack>
+          }
+        >
+          <Text fw={'bold'} c={'red'} size={'sm'}>
+            {props.missingDeps.length} Missing{' '}
+            {props.missingDeps.length > 1 ? 'Dependencies' : 'Dependency'}
           </Text>
         </Tooltip>
       </Table.Td>
@@ -80,6 +118,7 @@ export type SubscriptionRowProps = {
   stateLabel: string
   progress: number
   errors: string[]
+  missingDeps: EntryIndexSimple[]
 }
 
 export function SubscriptionRow(props: SubscriptionRowProps) {
@@ -129,6 +168,7 @@ export function SubscriptionRow(props: SubscriptionRowProps) {
         progress={props.progress}
         isLatest={props.isLatest}
         latestVersion={props.latestVersion}
+        missingDeps={props.missingDeps}
       />
       <Table.Td>{new Date(props.created).toLocaleString()}</Table.Td>
       <Table.Td>

--- a/src/renderer/src/container/subscriptions.tsx
+++ b/src/renderer/src/container/subscriptions.tsx
@@ -138,6 +138,9 @@ export function Subscriptions({ onOpenSymlinksModal }: SubscriptionsProps) {
                 enabled={state.enabled}
                 onToggleMod={() => handleToggleMod(subscription.modId)}
                 stateLabel={state.currentTaskLabel || state.progressLabel}
+                missingDeps={subscription.dependencies?.filter(
+                  (dep) => !results.some((sub) => sub.subscription.modId === dep.id)
+                )}
                 onRunExe={
                   state.exePath
                     ? () => state.exePath && handleRunExe(subscription.modId, state.exePath)

--- a/src/renderer/src/container/subscriptions.tsx
+++ b/src/renderer/src/container/subscriptions.tsx
@@ -63,9 +63,13 @@ export function Subscriptions({ onOpenSymlinksModal }: SubscriptionsProps) {
 
   async function handleToggleMod(sub: Subscription) {
     try {
-      await client.toggleMod.mutate({ modId: sub.modId })
-      if (sub.dependencies) {
-        await Promise.all(sub.dependencies.map((dep) => client.toggleMod.mutate({ modId: dep.id }))) // This doesn't work if some are already enabled as they will disable (figure out how to only enable if parent is enabled)
+      const isEnabled = await client.toggleMod.mutate({ modId: sub.modId })
+      if (sub.dependencies && isEnabled) {
+        await Promise.all(
+          sub.dependencies.map((dep) =>
+            client.toggleMod.mutate({ modId: dep.id, enableOnly: true })
+          )
+        )
       }
       await subscriptions.mutate()
     } catch (err) {

--- a/src/renderer/src/hooks/useRegistrySubscriber.ts
+++ b/src/renderer/src/hooks/useRegistrySubscriber.ts
@@ -12,6 +12,18 @@ export const useRegistrySubscriber = (registryEntry: EntryIndexHydrated) => {
       try {
         console.log('Subscribed to registry entry:', registryEntry)
         await client.subscribe.mutate({ modId: registryEntry.id })
+        if (registryEntry.dependencies) {
+          for (const dependency of registryEntry.dependencies) {
+            try {
+              await client.subscribe.mutate({ modId: dependency.id })
+              showSuccessNotification(`Subscribed to ${dependency.name}`)
+            } catch (e) {
+              // Ignore errors for now
+              console.error('Failed to subscribe to dependency:', dependency, e)
+              showErrorNotification(e)
+            }
+          }
+        }
         showSuccessNotification(`Subscribed to ${registryEntry.name}`)
       } catch (e) {
         showErrorNotification(e)

--- a/src/renderer/src/hooks/useRegistrySubscriber.ts
+++ b/src/renderer/src/hooks/useRegistrySubscriber.ts
@@ -1,9 +1,9 @@
-import { EntryIndex } from '../../../lib/client'
+import { EntryIndexHydrated } from '../../../lib/client'
 import { client } from '../client'
 import { showErrorNotification, showSuccessNotification } from '../utils/notifications'
 import { useSubscriptions } from './useSubscriptions'
 
-export const useRegistrySubscriber = (registryEntry: EntryIndex) => {
+export const useRegistrySubscriber = (registryEntry: EntryIndexHydrated) => {
   const allSubscriptions = useSubscriptions()
 
   return {

--- a/src/renderer/src/pages/registry-entry.page.tsx
+++ b/src/renderer/src/pages/registry-entry.page.tsx
@@ -24,7 +24,7 @@ import React, { useEffect } from 'react'
 import { MdOutlineCategory } from 'react-icons/md'
 import { VscCheck, VscClose } from 'react-icons/vsc'
 import { useNavigate, useParams } from 'react-router-dom'
-import { EntryIndex } from '../../../lib/client'
+import { EntryIndexHydrated } from '../../../lib/client'
 import { ReleaseSummary } from '../components/release-summary'
 import { useRegistrySubscriber } from '../hooks/useRegistrySubscriber'
 import { useRegistryEntry } from '../hooks/useRegistryEntry'
@@ -62,7 +62,7 @@ export const RegistryEntryPage: React.FC = () => {
 }
 
 export type RegistryEntryPageProps = {
-  entry: EntryIndex
+  entry: EntryIndexHydrated
 }
 export const _RegistryEntryPage: React.FC<RegistryEntryPageProps> = ({ entry }) => {
   const navigate = useNavigate()
@@ -180,8 +180,11 @@ export const _RegistryEntryPage: React.FC<RegistryEntryPageProps> = ({ entry }) 
               {entry.dependencies ? (
                 <Stack gap={'xs'}>
                   {entry.dependencies.map((dependency) => (
-                    <Anchor key={dependency} onClick={() => navigate(`/library/${dependency}`)}>
-                      {dependency}
+                    <Anchor
+                      key={dependency.id}
+                      onClick={() => navigate(`/library/${dependency.id}`)}
+                    >
+                      {dependency.name || dependency.id}
                     </Anchor>
                   ))}
                 </Stack>

--- a/src/renderer/src/pages/registry-entry.page.tsx
+++ b/src/renderer/src/pages/registry-entry.page.tsx
@@ -170,6 +170,26 @@ export const _RegistryEntryPage: React.FC<RegistryEntryPageProps> = ({ entry }) 
 
             <Divider color={'gray'} />
 
+            <Divider color={'gray'} />
+            <Stack gap={'xs'}>
+              <Group justify={'space-between'}>
+                <Title order={4} fw={500}>
+                  Dependencies
+                </Title>
+              </Group>
+              {entry.dependencies ? (
+                <Stack gap={'xs'}>
+                  {entry.dependencies.map((dependency) => (
+                    <Anchor key={dependency} onClick={() => navigate(`/library/${dependency}`)}>
+                      {dependency}
+                    </Anchor>
+                  ))}
+                </Stack>
+              ) : (
+                <Text>No Dependencies Found</Text>
+              )}
+            </Stack>
+
             <Stack gap={'xs'}>
               <Group justify={'space-between'}>
                 <Title order={4} fw={500}>


### PR DESCRIPTION
Links to https://github.com/flying-dice/dcs-dropzone-registry/pull/37

Todo:

- [x] Display proper Dep name.
- [x] Highlight Missing Deps.
- [x] Auto Enable Deps when the mod is enabled. - Need only work when enabling and only enable deps
- [x] Subscribe to missing deps
- [x] Auto Subscribe to Deps if possible when subscribing to this mod (if not carry on may have manual installed it) 

This currently doesn't handle nested deps ei A deps on B and B deps on C. Maybe for the future but I think we have time till that issue)