### PR TITLE
Keep Error notifications  open long enough to copy

### DIFF
--- a/src/renderer/src/utils/notifications.ts
+++ b/src/renderer/src/utils/notifications.ts
@@ -11,7 +11,8 @@ export const showErrorNotification = (error: ErrorWithDetails) => {
   showNotification({
     color: 'red',
     title: error.title || 'Error',
-    message: error.message
+    message: error.message,
+    autoClose: 60000
   })
 }
 


### PR DESCRIPTION
60s is long enough to read it and take a good copy down (can reduce if gets annoying)
Fixes: #49 